### PR TITLE
fix for linux / gcc by changing main func return type to int - 

### DIFF
--- a/TensorFrost/Backend/CodeGen/Langs/CPP.cpp
+++ b/TensorFrost/Backend/CodeGen/Langs/CPP.cpp
@@ -434,7 +434,7 @@ void dispatch(int kernel_id, std::initializer_list<TensorProp> tensors, std::ini
 #ifdef _WIN32
 	    "__declspec(dllexport)"
 #endif
-	    " void "
+	    "int "
 	    "main"
 	    "(TensorProp* in, TensorProp* out, alloc_func alloc_, dealloc_func dealloc_, readback_func readback_, writeback_func writeback_, dispatch_func dispatch_)\n"
 	    "{\n"
@@ -457,7 +457,7 @@ void dispatch(int kernel_id, std::initializer_list<TensorProp> tensors, std::ini
 		host_code += "  out[" + to_string(i) + "] = std::get<" + to_string(i) + ">(outputs);\n";
 	}
 
-	host_code += "}\n";
+	host_code += "  return 0;\n}\n";
 
 	final_source += host_code;
 


### PR DESCRIPTION
runs great! 

the extra space before the return type was also unneeded


![image](https://github.com/MichaelMoroz/TensorFrost/assets/15711120/917ddfdb-9ee4-4ae3-bfaf-c472834176a9)
