### PR TITLE
Virtual Environment Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,15 @@
 *.dylib
 *.dll
 
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
 # Fortran module files
 *.mod
 *.smod

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Certain Linux distributions (e.g. Arch Linux) want you to use their package mana
     ```
 
 > [!TIP]
-> The newly-created venv is treated like a fresh Python installation, so you may need to reinstall any needed packages such as `numpy`, `matplotlib`, amd `tqdm`. `pip` works fine as usual once the venv is active (e.g. `pip install numpy`).
+> The newly-created venv is treated like a fresh Python installation, so you may need to reinstall any needed packages such as `numpy`, `matplotlib`, and `tqdm` if you are trying out the examples. `pip` works fine once the venv is active (e.g. `pip install numpy`).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ pip install tensorfrost
 
 ## From source
 
-You need to have CMake installed to build the library. 
+You need to have CMake installed to build the library.
 
 First clone the repository:
 ```bash
@@ -74,16 +74,51 @@ git clone --recurse-submodules https://github.com/MichaelMoroz/TensorFrost.git
 cd TensorFrost
 ```
 
-Then run cmake to build the library:
+Then run cmake to build the library.
+
 ```bash
 cmake -S . -B build && cmake --build build
 ```
+
+> [!TIP]
+> If you are using a Linux distribution that doesn't support installing packages through pip (e.g. Arch Linux), read **[Using a Virtual Environment](#using-a-virtual-environment)**.
 
 The cmake script will automatically install the compiled python module into your python environment.
 
 ### Building wheel packages (optional)
 
 You can either call `clean_rebuild.bat %PYTHON_VERSION%` to build the wheel packages for the specified python version (the version needs to be installed beforehand), or you can build them for all versions by calling `build_all_python_versions.bat`. The scripts will automatically build and install the library for each python version, and then build the wheel packages to the `PythonBuild/dist` folder.
+
+### Using a Virtual Environment
+
+Certain Linux distributions (e.g. Arch Linux) want you to use their package manager to manage system-wide Python packages instead of pip. TensorFrost uses pip to install itself once built, so before running CMake you will need to activate a Virtual Environment.
+
+1. From the TensorFrost directory, create a venv:
+
+    ```sh
+    python -m venv ./venv
+    ```
+
+2. Activate the venv:
+
+    ```sh
+    source venv/bin/activate
+    ```
+
+3. Install `jinja` (required for building)
+
+    ```sh
+    pip install jinja
+    ```
+
+4. Now, you can use CMake as usual.
+
+    ```bash
+    cmake -S . -B build && cmake --build build
+    ```
+
+> [!TIP]
+> The newly-created venv is treated like a fresh Python installation, so you may need to reinstall any needed packages such as `numpy`, `matplotlib`, amd `tqdm`. `pip` works fine as usual once the venv is active (e.g. `pip install numpy`).
 
 ## Usage
 

--- a/TensorFrost/Tensor/Tensor.h
+++ b/TensorFrost/Tensor/Tensor.h
@@ -8,6 +8,10 @@
 #include <vector>
 #include <variant>
 
+// for FLT_MAX, INT_MAX, etc.
+#include <float.h>
+#include <limits.h>
+
 #include <math.h>
 
 #include "Compiler/Graph/IR.h"


### PR DESCRIPTION
venv is required on Arch Linux, without adding venv (and other types of environments to the .gitignore), contributors' git will attempt to stage their environments. See https://github.com/github/gitignore/blob/8779ee73af62c669e7ca371aaab8399d87127693/Python.gitignore#L124-L131

This PR also includes details in the README detailing how to set up a Virtual Environment. (and fixes a GCC error due to `float.h` and `limits.h` not being explicitly included)