### PR TITLE
Add More Molecules + XYZ File Loader to VMC Example

### DIFF
--- a/examples/ML/VMC/atom.py
+++ b/examples/ML/VMC/atom.py
@@ -135,7 +135,7 @@ class Molecule:
 
         self.electron_count = self.spin_up_electrons + self.spin_down_electrons
 
-    def get_atoms(self) -> List[Vector4]:
+    def get_atoms(self) -> np.ndarray:
         atom_array = [[atom.position.x, atom.position.y, atom.position.z, atom.get_charge()] for atom in self.atoms]
         return np.array(atom_array, dtype=np.float32)
     

--- a/examples/ML/VMC/molecules.py
+++ b/examples/ML/VMC/molecules.py
@@ -1,19 +1,63 @@
 from utils import *
 from atom import *
 
-angstrom_to_bohr = 1.88973
+# https://physics.nist.gov/cgi-bin/cuu/Value?bohrrada0
+# a_0 = 5.291 772 105 44(82) x 10^-11 m
+angstrom_to_bohr = 1.0/0.529177210544
 
-atomH = Atom(1, "H", Vector3(3.015*0.5, 0.0, 0.0))
-atomLi = Atom(3, "Li", Vector3(-3.015*0.5, 0.0, 0.0))
-lih_molecule = Molecule([atomH, atomLi], "LiH", target_energy = -8.070548)
+# Hydrogen (H)
+atom = Atom(1, "H", Vector3(0.0, 0.0, 0.0))
+h_molecule = Molecule([atom], "Hydrogen", target_energy = -0.500273)
 
+# Carbon (C)
+atom = Atom(6, "C", Vector3(0.0, 0.0, 0.0))
+c_molecule = Molecule([atom], "Carbon", target_energy = -37.846772)
+
+# Nitrogen (N)
+atom = Atom(7, "N", Vector3(0.0, 0.0, 0.0))
+n_molecule = Molecule([atom], "Nitrogen", target_energy = -54.583861)
+
+# Oxygen (O)
+atom = Atom(8, "O", Vector3(0.0, 0.0, 0.0))
+o_molecule = Molecule([atom], "Oxygen", target_energy = -75.06655)
+
+# Fluorine (F)
+atom = Atom(9, "F", Vector3(0.0, 0.0, 0.0))
+f_molecule = Molecule([atom], "Fluorine", target_energy = -99.71873)
+
+# Neon (Ne)
+atom = Atom(10, "Ne", Vector3(0.0, 0.0, 0.0))
+ne_molecule = Molecule([atom], "Neon", target_energy = -128.9366)
+
+# Zinc (Zn)
+atomZn = Atom(30, "Zn", Vector3(0.0, 0.0, 0.0))
+zn_molecule = Molecule([atomZn], "Zinc", target_energy = -257.026)
+
+# Dilithium (Li2)
 atom1 = Atom(3, "Li", Vector3(-5.051*0.5, 0.0, 0.0))
 atom2 = Atom(3, "Li", Vector3(5.051*0.5, 0.0, 0.0))
 li2_molecule = Molecule([atom1, atom2], "Li2", target_energy = -14.9966)
 
-atom = Atom(6, "C", Vector3(0.0, 0.0, 0.0))
-c_molecule = Molecule([atom], "Carbon", target_energy = -37.846772)
+# Dihydrogen Monoxide (H2O)
+atomO = Atom(8, "O", Vector3(0.0, 0.0, 0.1173)*angstrom_to_bohr)
+atomH1 = Atom(1, "H", Vector3(0.0, -0.7572, -0.4696)*angstrom_to_bohr)
+atomH2 = Atom(1, "H", Vector3(0.0, 0.7572, -0.4696)*angstrom_to_bohr)
+h2o_molecule = Molecule([atomO, atomH1, atomH2], "Water", target_energy = -75.0104)
 
+# Zinc (Zn)
+atomZn = Atom(30, "Zn", Vector3(0.0, 0.0, 0.0))
+zn_molecule = Molecule([atomZn], "Zinc", target_energy = -257.026)
+
+# https://link.aps.org/doi/10.1103/PhysRevResearch.2.033429
+
+# Ammonia (NH3)
+atomN = Atom(7, "N", Vector3(0.0, 0.0, 0.22013))
+atomH1 = Atom(1, "H", Vector3(0.0, 1.77583, -0.51364))
+atomH2 = Atom(1, "H", Vector3(1.53791, -0.88791, -0.51364))
+atomH3 = Atom(1, "H", Vector3(-1.53791, -0.88791, -0.51364))
+nh3_molecule = Molecule([atomN, atomH1, atomH2, atomH3], "Ammonia", target_energy = -56.56295)
+
+# Methane (CH4)
 atomC = Atom(6, "C", Vector3(0.0, 0.0, 0.0))
 atomH1 = Atom(1, "H", Vector3(1.18886, 1.18886, 1.18886))
 atomH2 = Atom(1, "H", Vector3(-1.18886, -1.18886, 1.18886))
@@ -21,34 +65,16 @@ atomH3 = Atom(1, "H", Vector3(-1.18886, 1.18886, -1.18886))
 atomH4 = Atom(1, "H", Vector3(1.18886, -1.18886, -1.18886))
 ch4_molecule = Molecule([atomC, atomH1, atomH2, atomH3, atomH4], "Methane", target_energy = -40.51400)
 
-atom = Atom(8, "O", Vector3(0.0, 0.0, 0.0))
-o_molecule = Molecule([atom], "Oxygen", target_energy = -75.06655)
-
-atom = Atom(10, "Ne", Vector3(0.0, 0.0, 0.0))
-ne_molecule = Molecule([atom], "Neon", target_energy = -128.9366)
-
+# Ethylene (C2H4)
 atomC1 = Atom(6, "C", Vector3(0.0, 0.0, 1.26135))
 atomC2 = Atom(6, "C", Vector3(0.0, 0.0, -1.26135))
 atomH1 = Atom(1, "H", Vector3(0.0, 1.74390, 2.33889))
 atomH2 = Atom(1, "H", Vector3(0.0, -1.74390, 2.33889))
 atomH3 = Atom(1, "H", Vector3(0.0, 1.74390, -2.33889))
 atomH4 = Atom(1, "H", Vector3(0.0, -1.74390, -2.33889))
-c2h4_molecule = Molecule([atomC1, atomC2, atomH1, atomH2, atomH3, atomH4], "Ethane", target_energy = -78.5844)
+c2h4_molecule = Molecule([atomC1, atomC2, atomH1, atomH2, atomH3, atomH4], "Ethylene", target_energy = -78.5844)
 
-atomO = Atom(8, "O", Vector3(0.0, 0.0, 0.1173)*angstrom_to_bohr)
-atomH1 = Atom(1, "H", Vector3(0.0, -0.7572, -0.4696)*angstrom_to_bohr)
-atomH2 = Atom(1, "H", Vector3(0.0, 0.7572, -0.4696)*angstrom_to_bohr)
-h2o_molecule = Molecule([atomO, atomH1, atomH2], "Water", target_energy = -75.0104)
-
-atomZn = Atom(30, "Zn", Vector3(0.0, 0.0, 0.0))
-zn_molecule = Molecule([atomZn], "Zinc", target_energy = -257.026)
-
-atomN = Atom(7, "N", Vector3(0.0, 0.0, 0.22013))
-atomH1 = Atom(1, "H", Vector3(0.0, 1.77583, -0.51364))
-atomH2 = Atom(1, "H", Vector3(1.53791, -0.88791, -0.51364))
-atomH3 = Atom(1, "H", Vector3(-1.53791, -0.88791, -0.51364))
-nh3_molecule = Molecule([atomN, atomH1, atomH2, atomH3], "Ammonia", target_energy = -56.56295)
-
+# Methylamine (CH3NH2)
 atomC = Atom(6, "C", Vector3(0.0517, 0.7044, 0.0))
 atomN = Atom(7, "N", Vector3(0.0517, -0.7596, 0.0))
 atomH1 = Atom(1, "H", Vector3(-0.9417, 1.1762, 0.0))
@@ -58,6 +84,13 @@ atomH4 = Atom(1, "H", Vector3(0.5928, 1.0567, 0.8807))
 atomH5 = Atom(1, "H", Vector3(0.5928, 1.0567, -0.8807))
 ch3nh2_molecule = Molecule([atomC, atomN, atomH1, atomH2, atomH3, atomH4, atomH5], "Methylamine", target_energy = -95.8554)
 
+# Ozone (O3)
+atomO1 = Atom(8, "O", Vector3(0.0, 2.0859, -0.4319))
+atomO2 = Atom(8, "O", Vector3(0.0, 0.0, 0.8638))
+atomO3 = Atom(8, "O", Vector3(0.0, -2.0859, -0.4319))
+o3_molecule = Molecule([atomO1, atomO2, atomO3], "Ozone", target_energy = -225.4145)
+
+# Ethanol (C2H5OH)
 atomC1 = Atom(6, "C", Vector3(2.2075, -0.7566, 0.0))
 atomC2 = Atom(6, "C", Vector3(0.0, 1.0572, 0.0))
 atomO = Atom(8, "O", Vector3(-2.2489, -0.4302, 0.0))
@@ -66,9 +99,10 @@ atomH2 = Atom(1, "H", Vector3(0.0804, 2.2819, 1.6761))
 atomH3 = Atom(1, "H", Vector3(0.0804, 2.2819, -1.6761))
 atomH4 = Atom(1, "H", Vector3(3.9985, 0.2736, 0.0))
 atomH5 = Atom(1, "H", Vector3(2.1327, -1.9601, 1.6741))
-c2oh5_molecule = Molecule([atomC1, atomC2, atomO, atomH1, atomH2, atomH3, atomH4, atomH5], "Ethanol", target_energy = -155.0308)
+atomH6 = Atom(1, "H", Vector3(2.1327, -1.9601, -1.6741)) # forgotten in the paper?
+c2h5oh_molecule = Molecule([atomC1, atomC2, atomO, atomH1, atomH2, atomH3, atomH4, atomH5, atomH6], "Ethanol", target_energy = -155.0308)
 
-
+# Bicyclobutane (C4H6)
 atomC1 = Atom(6, "C", Vector3(0.0, 2.13792, 0.58661))
 atomC2 = Atom(6, "C", Vector3(0.0, -2.13792, 0.58661))
 atomC3 = Atom(6, "C", Vector3(1.41342, 0.0, -0.58924))

--- a/examples/ML/VMC/molecules.py
+++ b/examples/ML/VMC/molecules.py
@@ -5,9 +5,13 @@ from atom import *
 # a_0 = 5.291 772 105 44(82) x 10^-11 m
 angstrom_to_bohr = 1.0/0.529177210544
 
+# https://physics.nist.gov/cgi-bin/cuu/Value?hrev
+# E_h = 27.211 386 245 981(30) eV
+eV_to_hartree = 27.211386245981
+
 # Hydrogen (H)
 atom = Atom(1, "H", Vector3(0.0, 0.0, 0.0))
-h_molecule = Molecule([atom], "Hydrogen", target_energy = -0.500273)
+h_molecule = Molecule([atom], "Hydrogen", target_energy = -0.5)
 
 # Carbon (C)
 atom = Atom(6, "C", Vector3(0.0, 0.0, 0.0))

--- a/examples/ML/VMC/molecules/c_carbon.xyz
+++ b/examples/ML/VMC/molecules/c_carbon.xyz
@@ -1,0 +1,3 @@
+1
+TF name="Carbon" target_energy=-37.846772 comment="NIST Computational Chemistry Comparison and Benchmark Database\nNIST Standard Reference Database Number 101\nRelease 22, May 2022, Editor: Russell D. Johnson III\nhttp://cccbdb.nist.gov/\nDOI:10.18434/T47C7Z"
+C     0.000000000     0.000000000     0.000000000

--- a/examples/ML/VMC/molecules/h2_molecular_hydrogen.xyz
+++ b/examples/ML/VMC/molecules/h2_molecular_hydrogen.xyz
@@ -1,0 +1,4 @@
+2
+TF name="Molecular Hydrogen" target_energy=-1.173864 comment="NIST Computational Chemistry Comparison and Benchmark Database\nNIST Standard Reference Database Number 101\nRelease 22, May 2022, Editor: Russell D. Johnson III\nhttp://cccbdb.nist.gov/\nDOI:10.18434/T47C7Z"
+H     0.000000000     0.000000000    -0.370700000
+H     0.000000000     0.000000000     0.370700000

--- a/examples/ML/VMC/molecules/n2h4_hydrazine.xyz
+++ b/examples/ML/VMC/molecules/n2h4_hydrazine.xyz
@@ -1,0 +1,8 @@
+6
+TF name="Hydrazine" target_energy=-111.682321 comment="NIST Computational Chemistry Comparison and Benchmark Database\nNIST Standard Reference Database Number 101\nRelease 22, May 2022, Editor: Russell D. Johnson III\nhttp://cccbdb.nist.gov/\nDOI:10.18434/T47C7Z"
+N     0.000000000     0.723000000    -0.112300000
+N     0.000000000    -0.723000000    -0.112300000
+H    -0.447000000     1.003100000     0.756200000
+H     0.447000000    -1.003100000     0.756200000
+H     0.966300000     1.003100000     0.030100000
+H    -0.966300000    -1.003100000     0.030100000

--- a/examples/ML/VMC/read_xyz.py
+++ b/examples/ML/VMC/read_xyz.py
@@ -1,0 +1,137 @@
+from ast import literal_eval
+from numpy import ndarray
+from utils import *
+from atom import *
+
+# for parsing .xyz file comment without manually writing a complete parser
+from shlex import shlex,split
+
+# contains some useful functions (e.g. rotation, overlay, formulae, renumbering, etc.)
+from xyz_py import lab_to_num, load_xyz, load_xyz_comment
+
+def read_xyz(filename, use_custom_metadata=True, verbosity=3):
+	"""
+	Parameters
+	----------
+	filename: str
+		Filename of the .xyz file to load
+	use_custom_metadata: bool
+		If True, parameters will be loaded from the second line (comment) of the XYZ file.
+		
+		Expected Format:
+		
+		```
+		TF parameter1=value1 parameter2=value2 ...
+		```
+		
+		Format Example:
+		
+		```
+		TF name="Bicyclobutane" target_energy=-155.9263
+		```
+	verbosity: int
+		How verbose to be when printing file loading statistics
+		<=0: Nothing will be printed
+		  1: Files being loaded will be printed
+		  2: Files and statistics (e.g. name, # of atoms, etc.) will be printed
+		>=3: Every concievable detail (including custom metadata) about the file loading process will be printed (default)
+	"""
+
+	if(verbosity > 0):
+		print("load_xyz.py: Loading \""+filename+"\".")
+
+	molecule_name = filename
+
+	energy = -1.0
+
+	(labels, coords) = load_xyz(filename)
+
+	num_atoms = len(labels)
+
+	if(verbosity > 1):
+		print("\tAtoms: "+str(num_atoms))
+
+	number = lab_to_num(labels)
+
+	coords = [Vector3(x[0], x[1], x[2]) for x in coords]
+
+	atoms = [Atom(number[i], labels[i], coords[i]) for i in range(num_atoms)]
+
+	if(use_custom_metadata):
+		if(verbosity > 2):
+			print("\tUse Custom Metadata: "+str(use_custom_metadata))
+
+		comment = load_xyz_comment(filename)
+
+		#print(comment[:3])
+
+		if(comment[:3] == 'TF '):
+			if(verbosity > 1):
+				print("\tMetadata Found: True")
+
+			#print(comment)
+
+			#comment = comment.strip()
+
+			# remove the "magic number"
+			comment = comment[3:]
+
+			# Split parameters
+			metadata = split(comment)
+
+			#for param in metadata:
+			#	print(param+"\n")
+
+			for param in metadata:
+				'''
+				TODO: Shlex the Parameter
+				The comment could contain '=' which will be split, but this will just result in the text after
+				the '=' being cut off.
+				'''
+				#shlex(param)
+				key = param.split('=')
+
+				if(len(key) < 2):
+					raise Exception("Invalid parameter \'"+param+"\' in "+str(filename)+":\n\t"+comment)
+
+				match key[0]:
+					case 'name':
+						molecule_name = str(key[1])
+					case 'target_energy':
+						energy = float(key[1])
+					case 'comment':
+						if(verbosity > 2):
+							print("\tComment:")
+
+							comment_str = literal_eval('\"'+key[1]+'\"')
+
+							lines = comment_str.splitlines()
+
+							for line in lines:
+								print("\t\t"+line)
+
+					case _:
+						raise Exception("Invalid parameter \'"+param+"\' in "+str(filename)+":\n\t"+comment)
+		else:
+			# custom metadata not used
+			if(verbosity > 2):
+				print("\tMetadata Found: False")
+	else:
+		# Custom metadata not found
+		if(verbosity > 2):
+			print("\tUse Custom Metadata: "+str(use_custom_metadata))
+
+	if(verbosity > 1):
+		print("\tMolecule Name: "+str(molecule_name))
+
+	if energy <= 0.0:
+		if(verbosity > 1):
+			print("\tTarget Energy: Unspecified")
+
+		# energy was not set, so let the Molecule() class handle it
+		return Molecule(atoms, molecule_name)
+	
+	if(verbosity > 1):
+			print("\tTarget Energy: "+str(energy))
+
+	return Molecule(atoms, molecule_name, target_energy=energy)

--- a/examples/ML/VMC/vmc.py
+++ b/examples/ML/VMC/vmc.py
@@ -11,13 +11,15 @@ from utils import *
 from atom import *
 from logdet import *
 from molecules import *
+from read_xyz import *
 from visualizer import *
 
 tf.initialize(tf.opengl)
 
 register_logdet()
 
-molecule = c_molecule
+#molecule = c4h6_molecule
+molecule = read_xyz("examples/ML/VMC/molecules/n2h4_hydrazine.xyz", use_custom_metadata=True)
 
 lr0 = 0.005
 lr1 = 0.0005

--- a/examples/ML/VMC/vmc.py
+++ b/examples/ML/VMC/vmc.py
@@ -252,9 +252,9 @@ class PSI(tf.Module):
         logdet = tf.custom("logdet", [reordered], [reordered.shape[0]])
         logdet = tf.reshape(logdet, [orbitals.shape[0], self.determinants])
         logdet = tf.squeeze(logdet)
-        return logdet / 0.69314718056
+        return logdet / 0.693147180559945309
         #TODO: fix compiler bug here
-        return tf.squeeze(logdet / 0.69314718056)
+        return tf.squeeze(logdet / 0.693147180559945309)
 
     #computing psi in log space is more numerically stable
     def log_psi(self, electrons):


### PR DESCRIPTION
CODATA-precision Bohr Radius constant (in Angstroms), added Hydrogen (fails), Nitrogen, Flourine, corrected Ethane (C4H6)-> Ethylene (C4H4), added Ozone, Ethanol, and Bicyclobutane